### PR TITLE
Fix build error: replace logical OR in switch-case with fallthrough

### DIFF
--- a/src/widgets/copilot/components/Messages/helpers.tsx
+++ b/src/widgets/copilot/components/Messages/helpers.tsx
@@ -55,8 +55,8 @@ export const findSourceIcon = (
       return () => <IconYoutube />;
     case "application/pdf":
       return () => <IconPDF style={{ fill: "#F40F02" }} size={12} />;
-    case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
-      "application/vnd.oasis.opendocument.spreadsheet":
+    case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+    case "application/vnd.oasis.opendocument.spreadsheet":
       return () => <IconSheets />;
     case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
       return () => <IconGoogleDocs />;


### PR DESCRIPTION
`case 'a' || 'b':` won't match with either 'a' or 'b', but will match with 'true' because this evaluates
the boolean expression. We want to match either 'a' or 'b', so replaced that with

```
case 'a':
case 'b':
  doSomething()
```

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
