### PR TITLE
feat: deprecate integration_id in favor of deployment_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you're new, you should probably head over to [gooey.ai/copilot](https://gooey
 <script>
   GooeyEmbed.mount({
     target: "#gooey-embed",
-    integration_id: "Kbo", // Your Integration ID
+    deployment_id: "Kbo", // Your Deployment ID
   });
 </script>
 ```
@@ -27,7 +27,7 @@ If you use the lib.js provided from gooey.ai, the config will be automatically p
 <script src="https://gooey.ai/chat/<Name>-<Integration ID>/lib.js"></script>
 ```
 
-2. Replace `"Kbo"` with your Integration's ID, as it appears on the Copilot's Integration tab.
+2. Replace `"Kbo"` with your Deployment ID, as it appears on the Copilot's Deploy tab. (Note: `integration_id` is still supported for backwards compatibility but is deprecated.)
 
 ## Configuration Options
 
@@ -36,12 +36,15 @@ If you use the lib.js provided from gooey.ai, the config will be automatically p
 ```js
 const config = {
   target: "#gooey-embed",
-  integration_id: "Kbo",
+  deployment_id: "Kbo",
   mode: "popup" | "inline" | "fullscreen",
   enableAudioMessage: true,
   showSources: true,
   enablePhotoUpload: true,
   enableConversations: true,
+  secrets: {
+    GOOGLE_MAPS_API_KEY: "your-google-maps-api-key-here",
+  },
   branding: {
     name: "Farmer.CHAT",
     byLine: "By Digital Green",
@@ -77,9 +80,11 @@ GooeyEmbed.mount(config);
 
 Specifies the [CSS selector](https://www.w3schools.com/css/css_selectors.asp) of the div where the widget will be embedded.
 
-##### `integration_id: string` **Required**
+##### `deployment_id: string` **Required**
 
-The unique identifier for your Gooey Bot Integration. (Note that this is snake_case, to match the Gooey API `payload`)
+The unique identifier for your Gooey Bot Deployment. (Note that this is snake_case, to match the Gooey API `payload`)
+
+**Note:** `integration_id` is deprecated but still supported for backwards compatibility. Please use `deployment_id` going forward.
 
 ##### `mode: string (popup | inline)`
 
@@ -136,13 +141,13 @@ Controls visual aspects of the widget and defines the textual content and relate
 - `colors`: An object to set the theme colors for widget ( e.g Colored Links, Buttons etc.)
   - `primary`: string
   - `secondary`: string
-  - 
+
 ##### `secrets: object`
 
 Contains API keys and other sensitive configuration for third-party services.
 
 - `GOOGLE_MAPS_API_KEY`: Optional Google Maps API key that enables location search with autocomplete and interactive Google Maps for location input. If not provided, the widget falls back to OpenStreetMap (free, manual location selection only).
-  
+
 ##### `payload: object`
 
 Contains the data sent to the Gooey API.

--- a/src/api/streaming.ts
+++ b/src/api/streaming.ts
@@ -21,7 +21,7 @@ export const createStreamApi = async (
   body: any,
   cancelToken: any,
 ) => {
-  let url = new URL("/v3/integrations/stream/", apiUrl).toString();
+  let url = new URL("/v3/deployments/stream/", apiUrl).toString();
   const headers = getHeaders();
   const finalBody = {
     citation_style: "number",

--- a/src/contexts/MessagesContext.tsx
+++ b/src/contexts/MessagesContext.tsx
@@ -181,7 +181,7 @@ const MessagesContextProvider = ({
   const { config, layoutController } = useSystemContext();
   const { conversations, handleAddConversation } = useConversations(
     currentUserId,
-    config?.integration_id as string,
+    config?.deployment_id as string,
   );
 
   const [messages, setMessages] = useState(new Map());
@@ -324,7 +324,7 @@ const MessagesContextProvider = ({
             user_id: prevMessage?.user_id,
             title: payload?.title,
             timestamp: payload?.created_at,
-            bot_id: config?.integration_id,
+            bot_id: config?.deployment_id
           };
           updateCurrentConversation(conversationData);
           handleAddConversation(
@@ -363,7 +363,7 @@ const MessagesContextProvider = ({
       });
       scrollToMessage();
     },
-    [config?.integration_id, handleAddConversation, scrollToMessage],
+    [config?.deployment_id, handleAddConversation, scrollToMessage],
   );
 
   const sendPayload = async (payload: RequestModel) => {
@@ -378,7 +378,7 @@ const MessagesContextProvider = ({
 
       payload = {
         ...configPayload,
-        integration_id: config?.integration_id,
+        deployment_id: config?.deployment_id,
         user_id: currentUserId,
         ...payload,
       };

--- a/src/contexts/types.ts
+++ b/src/contexts/types.ts
@@ -1,6 +1,8 @@
 export interface CopilotConfigType {
   target: string;
-  integration_id: string;
+  deployment_id: string;
+  /** @deprecated Use deployment_id instead. This field will be removed in a future version. */
+  integration_id?: string;
   mode: "popup" | "inline" | "fullscreen";
   enableAudioMessage: boolean;
   enablePhotoUpload: boolean;

--- a/src/lib.tsx
+++ b/src/lib.tsx
@@ -18,9 +18,9 @@ class GooeyEmbedFactory {
         `Target not found: ${config.target}. Please provide a valid "target" selector in the config object.`,
       );
     }
-    if (!config.integration_id) {
+    if (!config.integration_id && !config.deployment_id) {
       throw new Error(
-        `Integration ID is required. Please provide an "integration_id" in the config object.`,
+        `Deployment ID is required. Please provide an "deployment_id" in the config object.`,
       );
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@ const defaultConfig = {
   enablePhotoUpload: true,
   enableAudioMessage: true,
   enableConversations: true,
-  integration_id: "Kbo",
+  deployment_id: "Kbo",
 };
 
 GooeyEmbed.mount({ target: "#popup", mode: "popup", ...defaultConfig });

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -44,6 +44,9 @@ export function CopilotChatWidget({
     enableAudioMessage: true,
     showSources: true,
     ...config,
+    // Normalize deployment_id: use deployment_id if present,
+    // otherwise fall back to integration_id for backwards compatibility
+    deployment_id: config?.deployment_id || config?.integration_id || "",
     branding: {
       showPoweredByGooey: true,
       ...config?.branding,

--- a/test.html
+++ b/test.html
@@ -10,8 +10,8 @@
 <div id="popup"></div>
 <script src="dist/lib.js"></script>
 <script>
-  GooeyEmbed.mount({ target: "#popup", integration_id: "MqL", mode: "popup" });
-  GooeyEmbed.mount({ target: "#inline", integration_id: "MqL", mode: "inline" });
+  GooeyEmbed.mount({ target: "#popup", deployment_id: "MqL", mode: "popup" });
+  GooeyEmbed.mount({ target: "#inline", deployment_id: "MqL", mode: "inline" });
 </script>
 </body>
 </html>


### PR DESCRIPTION
Update codebase and documentation to use deployment_id as the standard parameter name. integration_id is deprecated but remains supported for backwards compatibility.

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
