### PR TITLE
fix: add even left/right padding of 6px to the widget container

### DIFF
--- a/src/widgets/copilot/components/Messages/index.tsx
+++ b/src/widgets/copilot/components/Messages/index.tsx
@@ -58,9 +58,8 @@ const Messages = () => {
     <div
       ref={scrollContainerRef}
       className={clsx(
-        "flex-1 bg-white gpt-16 overflow-y-auto w-100 stable-scroll-container",
+        "flex-1 bg-white gpt-16 gpr-6 gpl-6 overflow-y-auto w-100 stable-scroll-container",
       )}
-      style={{ paddingLeft: "6px" }}
     >
       <div
         className="mw-760 d-flex flex-col gpl-8"


### PR DESCRIPTION
### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
