### PR TITLE
feat: pass run web URL into tool-call GUI state updates

### DIFF
--- a/src/contexts/ControllerUtils.ts
+++ b/src/contexts/ControllerUtils.ts
@@ -6,6 +6,7 @@ import type {
   RequestModel,
 } from "./MessagesContext";
 import type { CopilotConfigType } from "./types";
+import { Conversation } from "./ConversationLayer";
 
 export type CopilotChatWidgetController = {
   messages?: MessageMishmash[];
@@ -13,6 +14,7 @@ export type CopilotChatWidgetController = {
   onNewConversation?: () => void;
   setMessages?: (messages: MessageMishmash[]) => void;
   updateConfig?: (config: CopilotConfigType) => void;
+  setConversationData?: (conversation: Conversation) => void;
 };
 
 export function useController({
@@ -31,11 +33,11 @@ export function useController({
   let [messages, setMessages] = useState<Map<string, MessageMishmash>>(
     msgArrayToMap(controller?.messages || []),
   );
-  let ctx: MessagesContextType = {};
 
+  let ctx: MessagesContextType = {};
   if (!controller) return ctx;
 
-  if (typeof controller.messages !== "undefined") {
+  if (controller.messages) {
     ctx.messages = messages;
     controller.setMessages = (entries: MessageMishmash[]) => {
       let newMessages = msgArrayToMap(entries);
@@ -50,7 +52,7 @@ export function useController({
     ctx.initializeQuery = async (payload: RequestModel) => {
       if (!payload || isSending || isReceiving) return;
       await uploadPayloadFiles(payload, apiUrl);
-      controller.onSendMessage(payload);
+      controller.onSendMessage?.(payload);
     };
   }
 
@@ -73,10 +75,7 @@ function msgArrayToMap(
   return ret;
 }
 
-function isMapEqual(
-  map1: Map<string, MessageMishmash>,
-  map2: Map<string, MessageMishmash>,
-) {
+function isMapEqual(map1: Map<string, any>, map2: Map<string, any>) {
   if (map1.size !== map2.size) return false;
   return JSON.stringify([...map1]) === JSON.stringify([...map2]);
 }

--- a/src/contexts/ControllerUtils.ts
+++ b/src/contexts/ControllerUtils.ts
@@ -8,9 +8,9 @@ import type {
 import type { CopilotConfigType } from "./types";
 
 export type CopilotChatWidgetController = {
-  messages: MessageMishmash[];
-  onSendMessage: (payload: RequestModel) => void;
-  onNewConversation: () => void;
+  messages?: MessageMishmash[];
+  onSendMessage?: (payload: RequestModel) => void;
+  onNewConversation?: () => void;
   setMessages?: (messages: MessageMishmash[]) => void;
   updateConfig?: (config: CopilotConfigType) => void;
 };
@@ -31,23 +31,34 @@ export function useController({
   let [messages, setMessages] = useState<Map<string, MessageMishmash>>(
     msgArrayToMap(controller?.messages || []),
   );
-  if (!controller) return {};
-  controller.setMessages = (entries: MessageMishmash[]) => {
-    let newMessages = msgArrayToMap(entries);
-    if (!isMapEqual(messages, newMessages)) {
-      setMessages(newMessages);
-      scrollToMessage();
-    }
-  };
-  return {
-    messages,
-    async initializeQuery(payload: RequestModel) {
+  let ctx: MessagesContextType = {};
+
+  if (!controller) return ctx;
+
+  if (typeof controller.messages !== "undefined") {
+    ctx.messages = messages;
+    controller.setMessages = (entries: MessageMishmash[]) => {
+      let newMessages = msgArrayToMap(entries);
+      if (!isMapEqual(messages, newMessages)) {
+        setMessages(newMessages);
+        scrollToMessage();
+      }
+    };
+  }
+
+  if (controller.onSendMessage) {
+    ctx.initializeQuery = async (payload: RequestModel) => {
       if (!payload || isSending || isReceiving) return;
       await uploadPayloadFiles(payload, apiUrl);
-      controller?.onSendMessage(payload);
-    },
-    handleNewConversation: controller?.onNewConversation,
-  };
+      controller.onSendMessage(payload);
+    };
+  }
+
+  if (controller.onNewConversation) {
+    ctx.handleNewConversation = controller.onNewConversation;
+  }
+
+  return ctx;
 }
 
 function msgArrayToMap(

--- a/src/contexts/MessagesContext.tsx
+++ b/src/contexts/MessagesContext.tsx
@@ -412,7 +412,6 @@ const MessagesContextProvider = ({
         conversation.messages &&
         messagesChanged(Array.from(messages.values()), conversation.messages)
       ) {
-        console.log("preLoadData", conversation.messages);
         preLoadData(conversation.messages);
       }
     };
@@ -455,13 +454,25 @@ const MessagesContextProvider = ({
 export default MessagesContextProvider;
 
 function messagesChanged(array1: any[], array2: any[]): boolean {
-  if (array1.length !== array2.length) return true;
+  if (array1.length !== array2.length) {
+    return true;
+  }
   for (let i = 0; i < array1.length; i++) {
+    // compare the content of the messages, ignore the id
     if (
-      JSON.stringify(array1[i]?.content) !== JSON.stringify(array2[i]?.content)
+      JSON.stringify(array1[i], removeMsgId) !==
+      JSON.stringify(array2[i], removeMsgId)
     ) {
       return true;
     }
   }
   return false;
+}
+
+function removeMsgId(key: string, value: any) {
+  if (key === "id") {
+    return undefined;
+  } else {
+    return value;
+  }
 }

--- a/src/contexts/MessagesContext.tsx
+++ b/src/contexts/MessagesContext.tsx
@@ -231,7 +231,7 @@ const MessagesContextProvider = ({
       ? undefined
       : currentConversation.current?.id;
     setIsSendingMessage(true);
-    if (!conversationId && isSharedConversation) {
+    if (!conversationId && currentConversation.current?.messages) {
       // make messages array in payload from messages in currentConversation and add
       payload.messages = currentConversation.current?.messages?.map(
         (message) => ({
@@ -405,8 +405,19 @@ const MessagesContextProvider = ({
   }, [conversations]);
 
   if (controller) {
-    controller.setMessages = preLoadData;
+    controller.setConversationData = async (conversation: Conversation) => {
+      if (isSending || isReceiving) return;
+      currentConversation.current = conversation;
+      if (
+        conversation.messages &&
+        messagesChanged(Array.from(messages.values()), conversation.messages)
+      ) {
+        console.log("preLoadData", conversation.messages);
+        preLoadData(conversation.messages);
+      }
+    };
   }
+
   let controllerContext = useController({
     controller,
     apiUrl: config!.apiUrl!,
@@ -442,3 +453,15 @@ const MessagesContextProvider = ({
 };
 
 export default MessagesContextProvider;
+
+function messagesChanged(array1: any[], array2: any[]): boolean {
+  if (array1.length !== array2.length) return true;
+  for (let i = 0; i < array1.length; i++) {
+    if (
+      JSON.stringify(array1[i]?.content) !== JSON.stringify(array2[i]?.content)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/contexts/MessagesContext.tsx
+++ b/src/contexts/MessagesContext.tsx
@@ -59,8 +59,10 @@ export interface ConversationStart {
 
 export interface RunStart {
   type: "run_start";
-  // Add any additional fields as needed
-  // status_url?: string;
+  run_id: string;
+  web_url: string;
+  created_at: string;
+  status_url: string;
 }
 
 export interface MessagePart {
@@ -78,6 +80,11 @@ export interface MessagePart {
 
 export interface FinalResponse {
   type: "final_response";
+
+  run_id?: string;
+  web_url?: string;
+  created_at?: string;
+  status_url?: string;
 
   run_time_sec?: number;
   status?: string;
@@ -397,6 +404,9 @@ const MessagesContextProvider = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversations]);
 
+  if (controller) {
+    controller.setMessages = preLoadData;
+  }
   let controllerContext = useController({
     controller,
     apiUrl: config!.apiUrl!,

--- a/src/contexts/messages/useStreamingHandler.ts
+++ b/src/contexts/messages/useStreamingHandler.ts
@@ -72,6 +72,19 @@ export const useStreamingHandler = ({
           return newMessages;
         }
 
+        // run started
+        if (payload?.type === STREAM_MESSAGE_TYPES.RUN_START) {
+          const newMessages = new Map(prev);
+          const lastResponseId: any = Array.from(prev.keys()).pop();
+          const prevMessage = prev.get(lastResponseId);
+          if (!prevMessage) return prev;
+          newMessages.set(lastResponseId, {
+            ...prevMessage,
+            ...payload,
+          });
+          return newMessages;
+        }
+
         // stream end
         if (
           payload?.type === STREAM_MESSAGE_TYPES.FINAL_RESPONSE &&
@@ -121,16 +134,17 @@ export const useStreamingHandler = ({
           const newConversations = new Map(prev);
           const lastResponseId: any = Array.from(prev.keys()).pop(); // last messages id
           const prevMessage = prev.get(lastResponseId);
-          const text = (prevMessage?.text || "") + (payload.text || "");
+          if (!prevMessage) return prev;
+          const text = (prevMessage.text || "") + (payload.text || "");
           const buttons = [
-            ...(prevMessage?.buttons || []),
+            ...(prevMessage.buttons || []),
             ...(payload.buttons || []),
           ];
           let final_prompt = prevMessage.final_prompt || [];
           for (let [idx, value] of Object.entries(payload.prompt_delta || {})) {
             final_prompt[idx] = value;
             try {
-              handleToolCall(value, lastResponseId);
+              handleToolCall(value, prevMessage.web_url);
             } catch (e) {
               console.error(`Error handling tool call ${value}`, e);
             }

--- a/src/contexts/tools.ts
+++ b/src/contexts/tools.ts
@@ -4,7 +4,7 @@ declare global {
   }
 }
 
-export function handleToolCall(entry: any, lastMessageId?: string) {
+export function handleToolCall(entry: any, web_url?: string) {
   if (!entry) return;
 
   let update_gui_state = {};
@@ -20,7 +20,7 @@ export function handleToolCall(entry: any, lastMessageId?: string) {
         update_gui_state = {
           ...update_gui_state,
           ...state,
-          last_message_id: lastMessageId,
+          gooey_builder_web_url: web_url,
         };
         break;
       case "run_js": {

--- a/src/widgets/copilot/components/Messages/IncomingMsg.tsx
+++ b/src/widgets/copilot/components/Messages/IncomingMsg.tsx
@@ -125,7 +125,7 @@ const FeedbackButtons = ({
           )}
         </div>
       )}
-      {thumbButtons.length > 0 && (
+      {(thumbButtons.length > 0 || showRunLink) && (
         <div
           className="d-flex gmt-2 justify-content-start"
           style={{ gap: "4px" }}
@@ -141,25 +141,26 @@ const FeedbackButtons = ({
               <IconCopy size={14} />
             </IconButton>
           </GooeyTooltip>
-          {thumbButtons.map(
-            (button) =>
-              button && (
-                <FeedbackButton
-                  key={button.id}
-                  button={button}
-                  onClick={() => {
-                    if (button.isPressed) return;
-                    initializeQuery?.({
-                      button_pressed: {
-                        button_id: button.id,
-                        button_title: button.title,
-                        context_msg_id: bot_message_id,
-                      },
-                    });
-                  }}
-                />
-              ),
-          )}
+          {thumbButtons &&
+            thumbButtons.map(
+              (button) =>
+                button && (
+                  <FeedbackButton
+                    key={button.id}
+                    button={button}
+                    onClick={() => {
+                      if (button.isPressed) return;
+                      initializeQuery?.({
+                        button_pressed: {
+                          button_id: button.id,
+                          button_title: button.title,
+                          context_msg_id: bot_message_id,
+                        },
+                      });
+                    }}
+                  />
+                ),
+            )}
           {showRunLink && data?.web_url && (
             <a href={data?.web_url} target="_blank" rel="noopener noreferrer">
               <IconButton className="text-muted d-flex justify-content-center align-items-center h-100">

--- a/src/widgets/copilot/components/Messages/IncomingMsg.tsx
+++ b/src/widgets/copilot/components/Messages/IncomingMsg.tsx
@@ -261,8 +261,14 @@ const IncomingMsg = memo(
     const audioTrack = output_audio[0];
     const videoTrack = output_video[0];
     const isStreaming = type !== STREAM_MESSAGE_TYPES.FINAL_RESPONSE;
-    if (!props.data || type === STREAM_MESSAGE_TYPES.CONVERSATION_START)
+
+    if (
+      !props.data ||
+      type === STREAM_MESSAGE_TYPES.CONVERSATION_START ||
+      type === STREAM_MESSAGE_TYPES.RUN_START
+    ) {
       return <ResponseLoader show={true} />;
+    }
 
     return (
       <div className="gooey-incomingMsg gpb-12 mw-100">


### PR DESCRIPTION
- add run_start metadata fields (run_id, web_url, created_at, status_url) to message types
- merge RUN_START payload into the active streamed assistant message
- pass run web_url into update_gui_state tool call
- show run link button in incoming message feedback row when available
- add broader support for controller.setMessages even if controller.messages isn't provided

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
