### PR TITLE
feat: add onConversationChange controller callback for gooey builder

### DIFF
--- a/src/contexts/ControllerUtils.ts
+++ b/src/contexts/ControllerUtils.ts
@@ -15,6 +15,7 @@ export type CopilotChatWidgetController = {
   setMessages?: (messages: MessageMishmash[]) => void;
   updateConfig?: (config: CopilotConfigType) => void;
   setConversationData?: (conversation: Conversation) => void;
+  onConversationChange?: (conversationId: string) => void;
 };
 
 export function useController({

--- a/src/contexts/MessagesContext.tsx
+++ b/src/contexts/MessagesContext.tsx
@@ -213,6 +213,11 @@ const MessagesContextProvider = ({
   const apiSource = useRef(axios.CancelToken.source());
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const currentConversation = useRef<Conversation | null>(null);
+  const controllerRef = useRef(controller);
+
+  useEffect(() => {
+    controllerRef.current = controller;
+  }, [controller]);
 
   const updateCurrentConversation = (conversation: Conversation) => {
     currentConversation.current = {
@@ -357,6 +362,8 @@ const MessagesContextProvider = ({
   const setActiveConversation = useCallback(
     async (conversation: Conversation) => {
       if (isSending || isReceiving) cancelApiCall();
+      if (conversation.id && controllerRef.current?.onConversationChange)
+        return controllerRef.current?.onConversationChange?.(conversation.id);
       if (!conversation || currentConversation.current?.id === conversation.id)
         return setMessagesLoading(false);
       setMessagesLoading(true);
@@ -374,9 +381,7 @@ const MessagesContextProvider = ({
   );
 
   useEffect(() => {
-    let loadLatestConversation =
-      !layoutController?.showNewConversationButton &&
-      (config?.enableLastConversation ?? true);
+    let loadLatestConversation = !layoutController?.showNewConversationButton;
 
     if (loadLatestConversation && conversations?.length && !messages.size)
       // Load the latest conversation from DB - initial load when multiple conversations are disabled

--- a/src/contexts/MessagesContext.tsx
+++ b/src/contexts/MessagesContext.tsx
@@ -362,8 +362,7 @@ const MessagesContextProvider = ({
   const setActiveConversation = useCallback(
     async (conversation: Conversation) => {
       if (isSending || isReceiving) cancelApiCall();
-      if (conversation.id && controllerRef.current?.onConversationChange)
-        return controllerRef.current?.onConversationChange?.(conversation.id);
+
       if (!conversation || currentConversation.current?.id === conversation.id)
         return setMessagesLoading(false);
       setMessagesLoading(true);
@@ -373,6 +372,8 @@ const MessagesContextProvider = ({
       } else if (conversation.getMessages) {
         messages = await conversation.getMessages();
       }
+      if (conversation.id && controllerRef.current?.onConversationChange)
+        controllerRef.current?.onConversationChange?.(conversation.id);
       preLoadData(messages);
       updateCurrentConversation(conversation);
       setMessagesLoading(false);

--- a/src/contexts/types.ts
+++ b/src/contexts/types.ts
@@ -6,7 +6,6 @@ export interface CopilotConfigType {
   enablePhotoUpload: boolean;
   enableLipsyncVideo: boolean;
   enableConversations: boolean;
-  enableLastConversation?: boolean;
   autoPlayResponses: boolean;
   showSources: boolean;
   expandedSources: boolean;


### PR DESCRIPTION
- reomve config.enableLastConversation - no longer needed
- useRef for controller object
- pass covnersation.id to controllerRef.onConversationChange and no-op server will send the coonversation_data

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
