### PR TITLE
fix: embed Google Drive share links via /preview in iframes

### DIFF
--- a/src/components/shared/Response/MediaPreview.tsx
+++ b/src/components/shared/Response/MediaPreview.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import clsx from "clsx";
 
 import IconClose from "src/assets/SvgIcons/IconClose";
 import IconCopy from "src/assets/SvgIcons/IconCopy";
@@ -13,6 +14,8 @@ type MediaPreviewProps = {
   mediaType?: MediaType;
   poster?: string;
   showActions?: boolean;
+  /** Applied to inline img/video; skips default fluid sizing when set. */
+  inlineClassName?: string;
 };
 
 export const videoExtensions = new Set([
@@ -193,6 +196,20 @@ const styleContent = `
     margin-left: 3px;
     fill: #fff;
   }
+  .gw-media-inline-media {
+    max-width: 100%;
+    height: auto;
+    display: block;
+  }
+  .gw-media-inline-thumbnail {
+    display: block;
+  }
+  .gw-media-dialog-media {
+    max-width: 90vw;
+    max-height: 85vh;
+    width: 100%;
+    height: 100%;
+  }
 `;
 
 const MediaPreview = ({
@@ -201,6 +218,7 @@ const MediaPreview = ({
   mediaType,
   poster,
   showActions = true,
+  inlineClassName,
 }: MediaPreviewProps) => {
   const [open, setOpen] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -271,16 +289,20 @@ const MediaPreview = ({
     }
   };
 
-  const renderMedia = (variant: "inline" | "dialog") => {
-    const commonStyle =
-      variant === "inline"
-        ? { maxWidth: "100%", height: "auto", display: "block" }
-        : { maxWidth: "90vw", maxHeight: "85vh", width: "100%", height: "100%" };
+  const mediaClassName = (variant: "inline" | "dialog") =>
+    clsx(
+      variant === "dialog" && "gw-media-dialog-media",
+      variant === "inline" &&
+        (inlineClassName
+          ? ["gw-media-inline-thumbnail", inlineClassName]
+          : "gw-media-inline-media"),
+    );
 
+  const renderMedia = (variant: "inline" | "dialog") => {
     if (resolvedType === "video") {
       const videoElement = (
         <video
-          style={commonStyle}
+          className={mediaClassName(variant)}
           controls={variant === "dialog"}
           muted={variant === "inline"}
           autoPlay={variant === "dialog"}
@@ -321,7 +343,7 @@ const MediaPreview = ({
       <img
         src={src}
         alt={alt}
-        style={commonStyle}
+        className={mediaClassName(variant)}
         loading="lazy"
         aria-label={alt}
       />

--- a/src/widgets/copilot/components/ChatInput/FilePreview.tsx
+++ b/src/widgets/copilot/components/ChatInput/FilePreview.tsx
@@ -4,6 +4,8 @@ import IconFile from "src/assets/SvgIcons/IconFile";
 
 import IconButton from "src/components/shared/Buttons/IconButton";
 import { CircularLoader } from "src/components/shared/Loaders";
+import MediaPreview from "src/components/shared/Response/MediaPreview";
+import { addInlineStyle } from "src/addStyles";
 import { FullSourcePreview } from "../Messages/Sources";
 import { useSystemContext } from "src/contexts/hooks";
 import { SyntheticEvent } from "react";
@@ -12,6 +14,9 @@ import {
   isGoogleDocsEmbeddable,
   truncateMiddle,
 } from "../Messages/helpers";
+import style from "./chatInput.scss?inline";
+
+addInlineStyle(style);
 
 const FilePreview = ({
   files,
@@ -31,17 +36,19 @@ const FilePreview = ({
 
   const handleFileClick = (file: any) => {
     const fileURL = file?.url || URL.createObjectURL(file?.data);
-    if (isGoogleDocsEmbeddable(file?.data?.type || "")) {
+    const mimeType = file?.data?.type || "";
+    const fileKind = file?.type?.split("/")[0] || file?.type || "";
+    const isImage = mimeType.includes("image") || fileKind === "image";
+    const isVideo = mimeType.includes("video") || fileKind === "video";
+
+    if (isImage || isVideo) return;
+
+    if (isGoogleDocsEmbeddable(mimeType)) {
       openInSidebar({ url: fileURL, title: file.name });
-    } else if (
-      file?.data?.type?.includes("json") ||
-      file?.data?.type?.includes("image") || 
-      file?.url
-    ) {
+    } else if (mimeType.includes("json") || file?.url) {
       openInSidebar({
         url: fileURL,
         title: file.name,
-        isImage: file?.data?.type?.includes("image"),
       });
     } else {
       window.open(fileURL, "_blank");
@@ -49,25 +56,24 @@ const FilePreview = ({
   };
 
   return (
-    <div
-      className="d-flex overflow-scroll gooey-scroll-container"
-      style={{ gap: "12px", flexWrap: "nowrap", scrollbarWidth: "thin" }}
-    >
+    <div className="d-flex overflow-scroll gooey-scroll-container file-preview-list">
       {files.map((file, index) => {
         const { isUploading, data, url } = file;
         const fileURL = url || URL.createObjectURL(data);
-        const fileType = file?.type?.split("/")[0] || "application";
+        const fileType = file?.type?.split("/")[0] || file?.type || "application";
 
         return (
           <div key={index}>
-            {fileType === "image" ? (
-              <ImagePreviewItem
+            {fileType === "image" || fileType === "video" ? (
+              <MediaPreviewItem
                 onRemove={() => {
                   layoutController?.toggleSecondaryDrawer?.(null);
                   onRemove?.(file?.id);
                 }}
                 fileURL={fileURL}
-                onClick={() => handleFileClick(file)}
+                alt={file?.name || file?.title}
+                mediaType={fileType === "video" ? "video" : "image"}
+                showActions={!!url}
                 isUploading={isUploading}
                 isRemovable={!!onRemove}
               />
@@ -92,49 +98,34 @@ const FilePreview = ({
   );
 };
 
-const ImagePreviewItem = ({
+const MediaPreviewItem = ({
   onRemove,
   fileURL,
+  alt,
+  mediaType,
+  showActions,
   isUploading,
-  onClick,
   isRemovable,
 }: {
   onRemove: () => void;
   fileURL: string;
+  alt?: string;
+  mediaType: "image" | "video";
+  showActions: boolean;
   isUploading: boolean;
-  onClick: (e: SyntheticEvent) => void;
   isRemovable: boolean;
 }) => {
   return (
-    <div
-      className={clsx("file-preview-box br-large pos-relative cr-pointer")}
-      onClick={onClick}
-    >
+    <div className={clsx("file-preview-box br-large pos-relative")}>
       {isUploading && (
-        <div
-          style={{
-            position: "absolute",
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-            zIndex: 1,
-          }}
-        >
-          <span style={{ zIndex: 2 }}>
+        <div className="file-preview-loader">
+          <span className="file-preview-loader-inner">
             <CircularLoader size={32} />
           </span>
         </div>
       )}
       {isRemovable && (
-        <div
-          style={{
-            position: "absolute",
-            top: "6px",
-            right: "-16px",
-            transform: "translate(-50%, -50%)",
-            zIndex: 1,
-          }}
-        >
+        <div className="file-preview-remove">
           <IconButton
             className="bg-white gp-4 b-1"
             onClick={(e) => {
@@ -153,7 +144,13 @@ const ImagePreviewItem = ({
           "overflow-hidden file-preview-box",
         )}
       >
-        <img src={fileURL} alt={`preview-${name}`} className={"br-large b-1"} />
+        <MediaPreview
+          src={fileURL}
+          alt={alt}
+          mediaType={mediaType}
+          showActions={showActions}
+          inlineClassName="br-large b-1"
+        />
       </div>
     </div>
   );

--- a/src/widgets/copilot/components/ChatInput/chatInput.scss
+++ b/src/widgets/copilot/components/ChatInput/chatInput.scss
@@ -50,9 +50,37 @@
   top: 3px;
 }
 
-.file-preview-box img {
+.file-preview-list {
+  gap: 12px;
+  flex-wrap: nowrap;
+  scrollbar-width: thin;
+}
+
+.file-preview-loader {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+}
+
+.file-preview-loader-inner {
+  z-index: 2;
+}
+
+.file-preview-remove {
+  position: absolute;
+  top: 6px;
+  right: -16px;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+}
+
+.file-preview-box img,
+.file-preview-box video {
   height: 60px;
   width: 100px;
+  max-height: 60px;
   object-fit: cover;
 }
 

--- a/src/widgets/copilot/components/Messages/helpers.tsx
+++ b/src/widgets/copilot/components/Messages/helpers.tsx
@@ -243,11 +243,19 @@ export const getEmbedUrl = (url: string) => {
 
     // Google Drive share links (.../view) fail in iframes; use the /preview
     // embed instead. NOTE: the file must be shared as "Anyone with the link".
-    if (url.includes("drive.google.com")) {
-      const fileId = extractGoogleDriveFileId(url);
-      if (fileId) {
-        return `https://drive.google.com/file/d/${fileId}/preview`;
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname === "drive.google.com") {
+        const fileId = extractGoogleDriveFileId(url);
+        // Pre-2021 share links need their resourcekey; rebuilding the URL would
+        // drop it and break the preview, so keep the original URL for those.
+        if (fileId && !parsed.searchParams.has("resourcekey")) {
+          return `https://drive.google.com/file/d/${fileId}/preview`;
+        }
+        return url;
       }
+    } catch {
+      // not a valid absolute URL; fall through
     }
 
     // gview ignores #page=N in the encoded url param; native PDF viewer does not

--- a/src/widgets/copilot/components/Messages/helpers.tsx
+++ b/src/widgets/copilot/components/Messages/helpers.tsx
@@ -213,6 +213,22 @@ export function isGoogleDocsEmbeddable(input: string): boolean {
     return false;
   }
 }
+// Extracts a Google Drive file ID from a share URL (`/file/d/<id>/`, `?id=<id>`,
+// `/d/<id>`). IDs are URL-safe base64, typically ~33 chars. Returns null if none.
+export function extractGoogleDriveFileId(url: string): string | null {
+  if (!url) return null;
+  const patterns = [
+    /\/file\/d\/([-\w]{25,})/, // .../file/d/<id>/view
+    /[?&]id=([-\w]{25,})/, // ...?id=<id>
+    /\/d\/([-\w]{25,})/, // .../d/<id>
+  ];
+  for (const re of patterns) {
+    const m = url.match(re);
+    if (m?.[1]) return m[1];
+  }
+  return null;
+}
+
 export const getEmbedUrl = (url: string) => {
   try {
     // Check if it's a YouTube URL
@@ -223,6 +239,15 @@ export const getEmbedUrl = (url: string) => {
     if (match && match[1]) {
       // Return the embedded YouTube URL format
       return `https://www.youtube.com/embed/${match[1]}`;
+    }
+
+    // Google Drive share links (.../view) fail in iframes; use the /preview
+    // embed instead. NOTE: the file must be shared as "Anyone with the link".
+    if (url.includes("drive.google.com")) {
+      const fileId = extractGoogleDriveFileId(url);
+      if (fileId) {
+        return `https://drive.google.com/file/d/${fileId}/preview`;
+      }
     }
 
     // gview ignores #page=N in the encoded url param; native PDF viewer does not


### PR DESCRIPTION
Drive /view links fail inside iframes due to cross-site cookie restrictions. Detect drive.google.com links in getEmbedUrl, extract the file ID, and return the /preview embed URL instead.

### Legal Boilerplate

Look, I get it. The entity doing business as “Gooey.AI” and/or “Dara.network” was incorporated in the State of Delaware in 2020 as Dara Network Inc. and is gonna need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Dara Network Inc can use, modify, copy, and redistribute my contributions, under its choice of terms.
